### PR TITLE
Add node signal publishers for leds interfaces to handle stuck condition

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
@@ -17,9 +17,13 @@
 
 #include <string>
 #include "behaviortree_cpp/control_node.h"
+#include "nav2_msgs/msg/node_signal.hpp"
+#include "rclcpp/rclcpp.hpp"
 
 namespace nav2_behavior_tree
 {
+
+using NodeSignal = nav2_msgs::msg::NodeSignal;
 /**
  * @brief The RecoveryNode has only two children and returns SUCCESS if and only if the first child
  * returns SUCCESS.
@@ -64,6 +68,9 @@ private:
   unsigned int current_child_idx_;
   unsigned int number_of_retries_;
   unsigned int retry_count_;
+
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Publisher<NodeSignal>::SharedPtr node_status_pub_;
 
   /**
    * @brief The main override required by a BT action

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.hpp
@@ -26,10 +26,12 @@
 #include "nav2_behavior_tree/bt_utils.hpp"
 #include "nav2_behavior_tree/json_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "nav2_msgs/msg/node_signal.hpp"
 
 namespace nav2_behavior_tree
 {
 
+using NodeSignal = nav2_msgs::msg::NodeSignal;
 /**
  * @brief A BT::DecoratorNode that ticks its child every time when the length of
  * the new path is smaller than the old one by the length given by the user.
@@ -111,7 +113,9 @@ private:
   double prox_len_ = std::numeric_limits<double>::max();
   double length_factor_ = std::numeric_limits<double>::max();
   rclcpp::Node::SharedPtr node_;
+  rclcpp::Publisher<NodeSignal>::SharedPtr signal_pub_;
   bool first_time_ = true;
+  bool current_signal_state_ = false;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/plugins/control/recovery_node.cpp
+++ b/nav2_behavior_tree/plugins/control/recovery_node.cpp
@@ -26,6 +26,9 @@ RecoveryNode::RecoveryNode(
   number_of_retries_(1),
   retry_count_(0)
 {
+  node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+  rclcpp::QoS node_signal_qos = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().transient_local();
+  node_status_pub_ = rclcpp::create_publisher<NodeSignal>(node_, "/node_signal", node_signal_qos);
 }
 
 BT::NodeStatus RecoveryNode::tick()
@@ -53,9 +56,15 @@ BT::NodeStatus RecoveryNode::tick()
         case BT::NodeStatus::SUCCESS:
           // reset node and return success when first child returns success
           // also halt the recovery action as the main action is successful, reset its state
-          ControlNode::haltChild(1);
-          halt();
-          return BT::NodeStatus::SUCCESS;
+          {
+            NodeSignal stuck_signal_msg_;
+            stuck_signal_msg_.signal = NodeSignal::STUCK;
+            stuck_signal_msg_.state = false;
+            node_status_pub_->publish(stuck_signal_msg_);
+            ControlNode::haltChild(1);
+            halt();
+            return BT::NodeStatus::SUCCESS;
+          }
 
         case BT::NodeStatus::RUNNING:
           return BT::NodeStatus::RUNNING;
@@ -64,6 +73,10 @@ BT::NodeStatus RecoveryNode::tick()
           {
             if (retry_count_ < number_of_retries_) {
               // halt first child and tick second child in next iteration
+              NodeSignal stuck_signal_msg_;
+              stuck_signal_msg_.signal = NodeSignal::STUCK;
+              stuck_signal_msg_.state = true;
+              node_status_pub_->publish(stuck_signal_msg_);
               ControlNode::haltChild(0);
               current_child_idx_++;
               break;

--- a/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.cpp
+++ b/nav2_behavior_tree/plugins/decorator/path_longer_on_approach.cpp
@@ -18,6 +18,7 @@
 #include "nav2_util/geometry_utils.hpp"
 
 #include "nav2_behavior_tree/plugins/decorator/path_longer_on_approach.hpp"
+#include "rclcpp/qos.hpp"
 
 namespace nav2_behavior_tree
 {
@@ -28,6 +29,8 @@ PathLongerOnApproach::PathLongerOnApproach(
 : BT::DecoratorNode(name, conf)
 {
   node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+  rclcpp::QoS node_signal_qos = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().transient_local();
+  signal_pub_ = rclcpp::create_publisher<NodeSignal>(node_, "/node_signal", node_signal_qos);
 }
 
 bool PathLongerOnApproach::isPathUpdated(
@@ -77,6 +80,16 @@ inline BT::NodeStatus PathLongerOnApproach::tick()
   if (isPathUpdated(new_path_, old_path_) && isRobotInGoalProximity(old_path_, prox_len_) &&
     isNewPathLonger(new_path_, old_path_, length_factor_) && !first_time_)
   {
+    //Publish stuck signal
+    NodeSignal node_signal_msg;
+    node_signal_msg.signal = node_signal_msg.STUCK;
+    node_signal_msg.state = true;
+    if (current_signal_state_ != node_signal_msg.state)
+    {
+      signal_pub_->publish(node_signal_msg);
+      current_signal_state_ = node_signal_msg.state;
+    }
+
     const BT::NodeStatus child_state = child_node_->executeTick();
     switch (child_state) {
       case BT::NodeStatus::SKIPPED:
@@ -94,6 +107,17 @@ inline BT::NodeStatus PathLongerOnApproach::tick()
   }
   old_path_ = new_path_;
   first_time_ = false;
+
+  //Publish not stuck signal
+  NodeSignal node_signal_msg;
+  node_signal_msg.signal = node_signal_msg.STUCK;
+  node_signal_msg.state = false;
+  if (current_signal_state_ != node_signal_msg.state)
+  {
+    signal_pub_->publish(node_signal_msg);
+    current_signal_state_ = node_signal_msg.state;
+  }
+
   return BT::NodeStatus::SUCCESS;
 }
 


### PR DESCRIPTION
- Add publishers in path_longer_on_approach plugin & recovery_node plugin to publish node signal data for led interfaces.