### PR TITLE
Redesign stuck signal logic

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.hpp
@@ -20,6 +20,9 @@
 #include "nav2_msgs/action/compute_path_to_pose.hpp"
 #include "nav_msgs/msg/path.h"
 #include "nav2_behavior_tree/bt_action_node.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "nav2_msgs/msg/node_signal.hpp"
+#include "nav2_msgs/msg/warning_command.hpp"
 
 namespace nav2_behavior_tree
 {
@@ -33,7 +36,14 @@ class ComputePathToPoseAction : public BtActionNode<nav2_msgs::action::ComputePa
 {
   using Action = nav2_msgs::action::ComputePathToPose;
   using ActionResult = Action::Result;
-
+  using NodeSignal = nav2_msgs::msg::NodeSignal;
+  using WarningCommand = nav2_msgs::msg::WarningCommand;
+private:
+  geometry_msgs::msg::PoseStamped current_goal_;
+  bool use_stuck_signal_;
+  bool still_stuck_;
+  rclcpp::Publisher<NodeSignal>::SharedPtr node_status_pub_;
+  rclcpp::Publisher<WarningCommand>::SharedPtr warning_cmd_pub_;
 public:
   /**
    * @brief A constructor for nav2_behavior_tree::ComputePathToPoseAction
@@ -45,6 +55,8 @@ public:
     const std::string & xml_tag_name,
     const std::string & action_name,
     const BT::NodeConfiguration & conf);
+
+  void sendSignals(bool isStuck, bool newGoal);
 
   /**
    * @brief Function to perform some user-defined operation on tick
@@ -99,6 +111,7 @@ public:
         BT::InputPort<std::string>(
           "planner_id", "",
           "Mapped name to the planner plugin type to use"),
+        BT::InputPort<bool>("use_stuck_signal", false, "Use stuck signal"),
         BT::OutputPort<nav_msgs::msg::Path>("path", "Path created by ComputePathToPose node"),
         BT::OutputPort<ActionResult::_error_code_type>(
           "error_code_id", "The compute path to pose error code"),

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_pose_occupied_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/is_pose_occupied_condition.hpp
@@ -25,6 +25,8 @@
 #include "nav2_util/service_client.hpp"
 #include "nav2_behavior_tree/bt_utils.hpp"
 #include "nav2_behavior_tree/json_utils.hpp"
+#include "nav2_msgs/msg/node_signal.hpp"
+#include "nav2_msgs/msg/warning_command.hpp"
 
 
 namespace nav2_behavior_tree
@@ -36,6 +38,8 @@ namespace nav2_behavior_tree
  */
 class IsPoseOccupiedCondition : public BT::ConditionNode
 {
+  using NodeSignal = nav2_msgs::msg::NodeSignal;
+  using WarningCommand = nav2_msgs::msg::WarningCommand;
 public:
   /**
    * @brief A constructor for nav2_behavior_tree::IsPoseOccupiedCondition
@@ -47,6 +51,8 @@ public:
     const BT::NodeConfiguration & conf);
 
   IsPoseOccupiedCondition() = delete;
+
+  void sendSignals(bool isStuck, bool newPose);
 
   /**
    * @brief The main override required by a BT action
@@ -86,6 +92,7 @@ public:
         "consider_unknown_as_obstacle", false,
         "Whether to consider unknown cost as obstacle"),
       BT::InputPort<std::chrono::milliseconds>("server_timeout"),
+      BT::InputPort<bool>("use_stuck_signal", false, "Use stuck signal"),
     };
   }
 
@@ -99,6 +106,11 @@ private:
   bool consider_unknown_as_obstacle_;
   double cost_threshold_;
   std::string service_name_;
+  geometry_msgs::msg::PoseStamped current_pose_;
+  bool use_stuck_signal_;
+  bool still_stuck_;
+  rclcpp::Publisher<NodeSignal>::SharedPtr node_status_pub_;
+  rclcpp::Publisher<WarningCommand>::SharedPtr warning_cmd_pub_;
 };
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
@@ -18,14 +18,9 @@
 #include <string>
 #include "behaviortree_cpp/control_node.h"
 #include "rclcpp/rclcpp.hpp"
-#include "nav2_msgs/msg/node_signal.hpp"
-#include "nav2_msgs/msg/warning_command.hpp"
 
 namespace nav2_behavior_tree
 {
-
-using NodeSignal = nav2_msgs::msg::NodeSignal;
-using WarningCommand = nav2_msgs::msg::WarningCommand;
 
 /**
  * @brief The RecoveryNode has only two children and returns SUCCESS if and only if the first child
@@ -64,7 +59,6 @@ public:
   {
     return {
       BT::InputPort<int>("number_of_retries", 1, "Number of retries"),
-      BT::InputPort<bool>("use_stuck_signal", true, "Use stuck signal"),
     };
   }
 
@@ -72,13 +66,8 @@ private:
   unsigned int current_child_idx_;
   unsigned int number_of_retries_;
   unsigned int retry_count_;
-  bool still_stuck_;
-  bool use_stuck_signal_;
 
   rclcpp::Node::SharedPtr node_;
-  rclcpp::Publisher<NodeSignal>::SharedPtr node_status_pub_;
-  rclcpp::Publisher<WarningCommand>::SharedPtr warning_cmd_pub_;
-
   /**
    * @brief The main override required by a BT action
    * @return BT::NodeStatus Status of tick execution

--- a/nav2_behavior_tree/nav2_tree_nodes.xml
+++ b/nav2_behavior_tree/nav2_tree_nodes.xml
@@ -88,6 +88,7 @@
       <input_port name="planner_id">Mapped name to the planner plugin type to use</input_port>
       <input_port name="server_name">Server name</input_port>
       <input_port name="server_timeout">Server timeout</input_port>
+      <input_port name="use_stuck_signal">Wheter to publish stuck signal of led and audio</input_port>
       <output_port name="path">Path created by ComputePathToPose node</output_port>
       <output_port name="error_code_id">"Compute path to pose error code"</output_port>
       <output_port name="error_msg">"Compute path to pose error message"</output_port>
@@ -376,6 +377,7 @@
       <input_port name="use_footprint">Whether to use the footprint cost or the point cost</input_port>
       <input_port name="consider_unknown_as_obstacle"> If unknown cost is considered valid </input_port>
       <input_port name="server_timeout"> Server timeout </input_port>
+      <input_port name="use_stuck_signal">Wheter to publish stuck signal of led and audio</input_port>
     </Condition>
 
     <Condition ID="WouldAControllerRecoveryHelp">
@@ -401,7 +403,6 @@
 
     <Control ID="RecoveryNode">
       <input_port name="number_of_retries">Number of retries</input_port>
-      <input_port name="use_stuck_signal">Wheter to publish stuck signal of led and audio</input_port>
     </Control>
 
     <Control ID="RoundRobin"/>

--- a/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
+++ b/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
@@ -24,14 +24,58 @@ ComputePathToPoseAction::ComputePathToPoseAction(
   const std::string & xml_tag_name,
   const std::string & action_name,
   const BT::NodeConfiguration & conf)
-: BtActionNode<Action>(xml_tag_name, action_name, conf)
+: BtActionNode<Action>(xml_tag_name, action_name, conf) 
 {
+  still_stuck_ = false;
+  use_stuck_signal_ = false;
+  rclcpp::QoS node_signal_qos = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().transient_local();
+  node_status_pub_ = rclcpp::create_publisher<NodeSignal>(node_, "/node_signal", node_signal_qos);
+  warning_cmd_pub_ = rclcpp::create_publisher<WarningCommand>(node_, "/audio/warn/command", 10);
+}
+
+void ComputePathToPoseAction::sendSignals(bool isStuck, bool newGoal)
+{
+  NodeSignal stuck_signal_msg_;
+  stuck_signal_msg_.signal = NodeSignal::STUCK;
+  stuck_signal_msg_.state = isStuck;
+  node_status_pub_->publish(stuck_signal_msg_);
+
+  if (newGoal) {
+    return;
+  }
+
+  WarningCommand warning_cmd_msg;
+  if (isStuck) {
+    warning_cmd_msg.cmd = WarningCommand::PLAY_SIGNAL;
+    warning_cmd_msg.signal = WarningCommand::ROBOT_STUCK;
+    warning_cmd_msg.repeat = true;
+    warning_cmd_msg.period_s = 2;
+    warning_cmd_pub_->publish(warning_cmd_msg);
+  } else {
+    warning_cmd_msg.cmd = WarningCommand::STOP;
+    warning_cmd_pub_->publish(warning_cmd_msg);
+  }
 }
 
 void ComputePathToPoseAction::on_tick()
 {
   getInput("goal", goal_.goal);
   getInput("planner_id", goal_.planner_id);
+  getInput("use_stuck_signal", use_stuck_signal_);
+
+  bool same_goal =
+    (current_goal_.header.frame_id == goal_.goal.header.frame_id) &&
+    (current_goal_.header.stamp == goal_.goal.header.stamp) &&
+    (current_goal_.pose == goal_.goal.pose);
+
+  if (!same_goal) {
+    // RCLCPP_INFO(node_->get_logger(), "DEBUG: Not The same goal");
+    current_goal_ = goal_.goal;
+    if (use_stuck_signal_) {
+      sendSignals(false, true);
+    }
+    still_stuck_ = false;
+  } 
 
   // if "use_start" is provided try to enforce it (true or false), but we cannot enforce true if
   // start is not provided
@@ -60,6 +104,10 @@ BT::NodeStatus ComputePathToPoseAction::on_success()
   // Set empty error code, action was successful
   setOutput("error_code_id", ActionResult::NONE);
   setOutput("error_msg", "");
+  if (still_stuck_ && use_stuck_signal_) {
+    sendSignals(false, false);
+    still_stuck_ = false;
+  }
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -69,6 +117,10 @@ BT::NodeStatus ComputePathToPoseAction::on_aborted()
   setOutput("path", empty_path);
   setOutput("error_code_id", result_.result->error_code);
   setOutput("error_msg", result_.result->error_msg);
+  if (!still_stuck_ && use_stuck_signal_) {
+    sendSignals(true, false);
+    still_stuck_ = true;
+  }
   return BT::NodeStatus::FAILURE;
 }
 
@@ -79,6 +131,10 @@ BT::NodeStatus ComputePathToPoseAction::on_cancelled()
   // Set empty error code, action was cancelled
   setOutput("error_code_id", ActionResult::NONE);
   setOutput("error_msg", "");
+  if (still_stuck_ && use_stuck_signal_) {
+    sendSignals(false, false);
+    still_stuck_ = false;
+  }
   return BT::NodeStatus::SUCCESS;
 }
 
@@ -94,6 +150,10 @@ void ComputePathToPoseAction::halt()
   setOutput("path", empty_path);
   // DO NOT reset "error_code_id" output port, we want to read it later
   // DO NOT reset "error_msg" output port, we want to read it later
+  if (still_stuck_ && use_stuck_signal_) {
+    sendSignals(false, false);
+    still_stuck_ = false;
+  }
   BtActionNode::halt();
 }
 

--- a/nav2_behavior_tree/plugins/condition/is_pose_occupied_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/is_pose_occupied_condition.cpp
@@ -26,6 +26,8 @@ IsPoseOccupiedCondition::IsPoseOccupiedCondition(
 : BT::ConditionNode(condition_name, conf),
   use_footprint_(true), consider_unknown_as_obstacle_(false), cost_threshold_(254)
 {
+  still_stuck_ = false;
+  use_stuck_signal_ = false;
   initialize();
 }
 
@@ -34,6 +36,7 @@ void IsPoseOccupiedCondition::initialize()
   getInput<double>("cost_threshold", cost_threshold_);
   getInput<bool>("use_footprint", use_footprint_);
   getInput<bool>("consider_unknown_as_obstacle", consider_unknown_as_obstacle_);
+  getInput("use_stuck_signal", use_stuck_signal_);
   getInputOrBlackboard("server_timeout", server_timeout_);
   createROSInterfaces();
 }
@@ -49,6 +52,33 @@ void IsPoseOccupiedCondition::createROSInterfaces()
       // node_->create_client<nav2_msgs::srv::GetCosts>(
       // service_name_,
       // false /* Does not create and spin an internal executor*/);
+    rclcpp::QoS node_signal_qos = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().transient_local();
+    node_status_pub_ = rclcpp::create_publisher<NodeSignal>(node_, "/node_signal", node_signal_qos);
+    warning_cmd_pub_ = rclcpp::create_publisher<WarningCommand>(node_, "/audio/warn/command", 10);
+  }
+}
+
+void IsPoseOccupiedCondition::sendSignals(bool isStuck, bool newPose)
+{
+  NodeSignal stuck_signal_msg_;
+  stuck_signal_msg_.signal = NodeSignal::STUCK;
+  stuck_signal_msg_.state = isStuck;
+  node_status_pub_->publish(stuck_signal_msg_);
+
+  if (newPose) {
+    return;
+  }
+
+  WarningCommand warning_cmd_msg;
+  if (isStuck) {
+    warning_cmd_msg.cmd = WarningCommand::PLAY_SIGNAL;
+    warning_cmd_msg.signal = WarningCommand::ROBOT_STUCK;
+    warning_cmd_msg.repeat = true;
+    warning_cmd_msg.period_s = 2;
+    warning_cmd_pub_->publish(warning_cmd_msg);
+  } else {
+    warning_cmd_msg.cmd = WarningCommand::STOP;
+    warning_cmd_pub_->publish(warning_cmd_msg);
   }
 }
 
@@ -59,6 +89,20 @@ BT::NodeStatus IsPoseOccupiedCondition::tick()
   }
   geometry_msgs::msg::PoseStamped pose;
   getInput("pose", pose);
+
+  bool same_pose =
+    (current_pose_.header.frame_id == pose.header.frame_id) &&
+    (current_pose_.header.stamp == pose.header.stamp) &&
+    (current_pose_.pose == pose.pose);
+
+  if (!same_pose) {
+    // RCLCPP_INFO(node_->get_logger(), "DEBUG: Not The same goal");
+    current_pose_ = pose;
+    if (use_stuck_signal_) {
+      sendSignals(false, true);
+    }
+    still_stuck_ = false;
+  } 
 
   auto request = std::make_shared<nav2_msgs::srv::GetCosts::Request>();
   request->use_footprint = use_footprint_;
@@ -76,8 +120,16 @@ BT::NodeStatus IsPoseOccupiedCondition::tick()
   if ((response->costs[0] == 255 && !consider_unknown_as_obstacle_) ||
     response->costs[0] < cost_threshold_)
   {
+    if (still_stuck_ && use_stuck_signal_) {
+      sendSignals(false, false);
+      still_stuck_ = false;
+    }
     return BT::NodeStatus::FAILURE;
   } else {
+    if (!still_stuck_ && use_stuck_signal_) {
+      sendSignals(true, false);
+      still_stuck_ = true;
+    }
     return BT::NodeStatus::SUCCESS;
   }
 }

--- a/nav2_behavior_tree/plugins/control/recovery_node.cpp
+++ b/nav2_behavior_tree/plugins/control/recovery_node.cpp
@@ -24,20 +24,14 @@ RecoveryNode::RecoveryNode(
 : BT::ControlNode::ControlNode(name, conf),
   current_child_idx_(0),
   number_of_retries_(1),
-  retry_count_(0),
-  still_stuck_(false),
-  use_stuck_signal_(true)
+  retry_count_(0)
 {
   node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
-  rclcpp::QoS node_signal_qos = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().transient_local();
-  node_status_pub_ = rclcpp::create_publisher<NodeSignal>(node_, "/node_signal", node_signal_qos);
-  warning_cmd_pub_ = rclcpp::create_publisher<WarningCommand>(node_, "/audio/warn/command", 10);
 }
 
 BT::NodeStatus RecoveryNode::tick()
 {
   getInput("number_of_retries", number_of_retries_);
-  getInput("use_stuck_signal", use_stuck_signal_);
   const unsigned children_count = children_nodes_.size();
 
   if (children_count != 2) {
@@ -61,14 +55,6 @@ BT::NodeStatus RecoveryNode::tick()
           // reset node and return success when first child returns success
           // also halt the recovery action as the main action is successful, reset its state
           {
-            if (still_stuck_) {
-              if (use_stuck_signal_) {
-                WarningCommand warning_cmd_msg;
-                warning_cmd_msg.cmd = WarningCommand::STOP;
-                warning_cmd_pub_->publish(warning_cmd_msg);
-                still_stuck_ = false;
-              }
-            }
             ControlNode::haltChild(1);
             halt();
             return BT::NodeStatus::SUCCESS;
@@ -80,21 +66,6 @@ BT::NodeStatus RecoveryNode::tick()
         case BT::NodeStatus::FAILURE:
           {
             if (retry_count_ < number_of_retries_) {
-              // halt first child and tick second child in next iteration
-              if (use_stuck_signal_) {
-                NodeSignal stuck_signal_msg_;
-                stuck_signal_msg_.signal = NodeSignal::STUCK;
-                stuck_signal_msg_.state = true;
-                node_status_pub_->publish(stuck_signal_msg_);
-                
-                WarningCommand warning_cmd_msg;
-                warning_cmd_msg.cmd = WarningCommand::PLAY_SIGNAL;
-                warning_cmd_msg.signal = WarningCommand::ROBOT_STUCK;
-                warning_cmd_msg.repeat = true;
-                warning_cmd_msg.period_s = 2;
-                warning_cmd_pub_->publish(warning_cmd_msg);
-                still_stuck_ = true;
-              }
               ControlNode::haltChild(0);
               current_child_idx_++;
               break;
@@ -126,14 +97,7 @@ BT::NodeStatus RecoveryNode::tick()
 
         case BT::NodeStatus::SUCCESS:
           {
-            // halt second child, increment recovery count, and tick first child in next iteration
-            if (use_stuck_signal_) {
-              NodeSignal stuck_signal_msg_;
-              stuck_signal_msg_.signal = NodeSignal::STUCK;
-              stuck_signal_msg_.state = false;
-              node_status_pub_->publish(stuck_signal_msg_);
-            }
-            
+            // halt second child, increment recovery count, and tick first child in next iteration            
             ControlNode::haltChild(1);
             retry_count_++;
             current_child_idx_ = 0;

--- a/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_smooth_goal_patience_and_recovery.xml
+++ b/nav2_bt_navigator/behavior_trees/navigate_to_pose_w_replanning_smooth_goal_patience_and_recovery.xml
@@ -20,7 +20,8 @@
                                    planner_id="{selected_planner}"
                                    server_name="/virtual/compute_path_to_pose"
                                    path="{virtual_path}"
-                                   error_code_id="{compute_virtual_path_error_code}"/>
+                                   error_code_id="{compute_virtual_path_error_code}"
+                                   use_stuck_signal="true"/>
               </Sequence>
               <ClearEntireCostmap name="ClearGlobalCostmap-Context"
                                   service_name="/virtual/global_costmap/clear_entirely_global_costmap"/>
@@ -51,7 +52,8 @@
               <Inverter>
                 <IsPoseOccupied pose="{goal}"
                                 cost_threshold="200"
-                                use_footprint="false"/>
+                                use_footprint="false"
+                                use_stuck_signal="true"/>
               </Inverter>
               <SequenceWithMemory name="CancelingControlAndWait">
                 <CancelControl name="ControlCancel"/>
@@ -73,8 +75,7 @@
               </RetryUntilSuccessful>
             </PathLongerOnApproach>
             <RecoveryNode name="FollowPath"
-                          number_of_retries="1"
-                          use_stuck_signal="false">
+                          number_of_retries="1">
               <FollowPath controller_id="{selected_controller}"
                           path="{smooth_path}"
                           error_code_id="{follow_path_error_code}"/>


### PR DESCRIPTION
Redesign stuck signal logic:
- Move turn on/off stuck signal from BT recovery node to ComputePathToPose node and IsPoseOccupied node
- Fix bug the stuck signal turning on and not turning off again when FollowPath action returns failed 